### PR TITLE
Fixed to be able to uninstall Red5 service since the service name is not correct

### DIFF
--- a/src/main/daemon/uninstall-service.bat
+++ b/src/main/daemon/uninstall-service.bat
@@ -2,7 +2,9 @@
 
 SETLOCAL
 
+set SERVICE_NAME=Red5
+
 echo Uninstalling Red5 service
-prunsrv //DS//REDFIVE 
+prunsrv //DS//%SERVICE_NAME%
 
 ENDLOCAL


### PR DESCRIPTION
I fixed the service name settings according to install-service.bat.
