### PR TITLE
Fixed to be set parameters including SPACE for prunsrv.exe

### DIFF
--- a/src/main/daemon/install-service.bat
+++ b/src/main/daemon/install-service.bat
@@ -67,7 +67,7 @@ echo Installing '%SERVICE_NAME%' service
     --Description "Red5 Media Server" ^
     --DisplayName "Red5 Media Server" ^
     --Install "%EXECUTABLE%" ^
-    --LogPath "%RED5_HOME%\logs" ^
+    --LogPath "%RED5_HOME%\log" ^
     --StdOutput "%RED5_HOME%\log\red5_service.log" ^
     --StdError "%RED5_HOME%\log\stderr.log" ^
     --Classpath "%CLASSPATH%" ^


### PR DESCRIPTION
Fixes Red5/red5-server#5

This changes are workaround for setting parameters including SPACE (e.g. C:\Program Files\Red5). I'm not good at making Windows bat file and don't know how to quote parameters in this case. Somehow, this workaround works for me.

How to verify:
- install Red5 service
  
  ``` sh
  > install-service.bat
  ```
- startup monitoring application
  
  ``` sh
  > prunmgr.exe //MS//Red5
  ```
- confirm the parameters for Red5 service
  
  Right click monitoring application in system tray, then select Configure. You can see the parameters set by install-service.bat.
  
  ![prunmgr-configure1](https://cloud.githubusercontent.com/assets/96569/4469282/082816da-490f-11e4-8847-f82d2d1b832e.png)
